### PR TITLE
【修复】 Windows 上编译时出现命令行超长问题

### DIFF
--- a/modules/spine_godot/SCsub
+++ b/modules/spine_godot/SCsub
@@ -1,13 +1,19 @@
+#!/usr/bin/env python
+
 Import('env')
+Import("env_modules")
 
 # Need to add the include path to env so the vsproj generator consumes it.
 if env["vsproj"]:
-    env.Append(CPPPATH=["#../spine_godot/spine-cpp/include"])
+    # env.Append(CPPPATH=["#../spine_godot/spine-cpp/include"])
+    env.Append(CPPPATH=["../spine_godot/spine-cpp/include"])
 
-env_spine_runtime = env.Clone()
+
+env_spine_runtime = env_modules.Clone()
 env_spine_runtime.Append(CPPPATH=["../spine_godot/spine-cpp/include"])
 env_spine_runtime.add_source_files(env.modules_sources, "spine-cpp/src/spine/*.cpp")
 env_spine_runtime.add_source_files(env.modules_sources, "*.cpp")
+
 
 # Needed on Clang to not have a gazillion -Winconsistent-missing-override warnings for GDCLASS
 # I do not understand why other modules using GDCLASS do not have this issue when compiling.


### PR DESCRIPTION
【修复】 Windows 上编译时出现命令行超长问题
 The command line is too long.
参考资料 https://github.com/SCons/scons/wiki/LongCmdLinesOnWin32
