### PR TITLE
【修复】指向其它类函数的链接错误

### DIFF
--- a/doc/tools/make_md.py
+++ b/doc/tools/make_md.py
@@ -1778,9 +1778,9 @@ def make_method_signature(
             ref_type_qualifier = ""
             if definition.name.startswith("_"):
                 ref_type_qualifier = "private_"
-            out += f"[`{definition.name}`](#class_{class_def.name.lower()}_{ref_type_qualifier.lower()}{ref_type.lower()}_{definition.name.lower()})"
+            out += f"[`{definition.name}`](class_{class_def.name.lower()}md#class_{class_def.name.lower()}_{ref_type_qualifier.lower()}{ref_type.lower()}_{definition.name.lower()})"
         else:
-            out += f"[`{definition.name}`](#class_{class_def.name.lower()}_{ref_type.lower()}_{definition.name.lower()})"
+            out += f"[`{definition.name}`](class_{class_def.name.lower()}.md#class_{class_def.name.lower()}_{ref_type.lower()}_{definition.name.lower()})"
     else:
         out += f"**{definition.name}**"
 


### PR DESCRIPTION
本应是：`./class_resourceloader#class_resourceloader_method_has_cached`

当前（错误的）：`#class_resourceloader_method_has_cached`