### PR TITLE
【新增】为GDScript函数补全提示文本增补括号

### DIFF
--- a/modules/gdscript/tests/scripts/completion/argument_options/argument_options.tscn
+++ b/modules/gdscript/tests/scripts/completion/argument_options/argument_options.tscn
@@ -1,3 +1,16 @@
 [gd_scene load_steps=1 format=3 uid="uid://dl28pdkxcjvym"]
 
+[sub_resource type="Animation" id="Animation_d1pub"]
+resource_name = "bounce"
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_gs7mj"]
+_data = {
+"bounce": SubResource("Animation_d1pub")
+}
+
 [node name="GetNode" type="Node"]
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+"": SubResource("AnimationLibrary_gs7mj")
+}

--- a/modules/gdscript/tests/scripts/completion/argument_options/play_inferred.cfg
+++ b/modules/gdscript/tests/scripts/completion/argument_options/play_inferred.cfg
@@ -1,0 +1,6 @@
+[input]
+scene="res://completion/argument_options/argument_options.tscn"
+[output]
+include=[
+    {"display": "\"bounce\""},
+]

--- a/modules/gdscript/tests/scripts/completion/argument_options/play_inferred.gd
+++ b/modules/gdscript/tests/scripts/completion/argument_options/play_inferred.gd
@@ -1,0 +1,5 @@
+@onready var anim := $AnimationPlayer
+
+func test():
+	anim.play(➡)
+    pass

--- a/modules/gdscript/tests/scripts/completion/argument_options/play_typed.cfg
+++ b/modules/gdscript/tests/scripts/completion/argument_options/play_typed.cfg
@@ -1,0 +1,6 @@
+[input]
+scene="res://completion/argument_options/argument_options.tscn"
+[output]
+include=[
+    {"display": "\"bounce\""},
+]

--- a/modules/gdscript/tests/scripts/completion/argument_options/play_typed.gd
+++ b/modules/gdscript/tests/scripts/completion/argument_options/play_typed.gd
@@ -1,0 +1,5 @@
+@onready var anim: AnimationPlayer = $AnimationPlayer
+
+func test():
+	anim.play(➡)
+    pass

--- a/modules/gdscript/tests/scripts/completion/argument_options/play_untyped.cfg
+++ b/modules/gdscript/tests/scripts/completion/argument_options/play_untyped.cfg
@@ -1,0 +1,6 @@
+[input]
+scene="res://completion/argument_options/argument_options.tscn"
+[output]
+include=[
+    {"display": "\"bounce\""},
+]

--- a/modules/gdscript/tests/scripts/completion/argument_options/play_untyped.gd
+++ b/modules/gdscript/tests/scripts/completion/argument_options/play_untyped.gd
@@ -1,0 +1,5 @@
+@onready var anim = $AnimationPlayer
+
+func test():
+	anim.play(➡)
+    pass

--- a/modules/gdscript/tests/scripts/completion/assignment_options/enum_attribute.cfg
+++ b/modules/gdscript/tests/scripts/completion/assignment_options/enum_attribute.cfg
@@ -1,6 +1,6 @@
 [output]
 include=[
-    {"display": "new"},
+    {"display": "new(…)"},
     {"display": "SIZE_EXPAND"},
     {"display": "SIZE_EXPAND_FILL"},
     {"display": "SIZE_FILL"},

--- a/modules/gdscript/tests/scripts/completion/assignment_options/enum_attribute_identifier.cfg
+++ b/modules/gdscript/tests/scripts/completion/assignment_options/enum_attribute_identifier.cfg
@@ -1,6 +1,6 @@
 [output]
 include=[
-    {"display": "new"},
+    {"display": "new(…)"},
     {"display": "SIZE_EXPAND"},
     {"display": "SIZE_EXPAND_FILL"},
     {"display": "SIZE_FILL"},

--- a/modules/gdscript/tests/scripts/completion/common/identifiers_in_call.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/identifiers_in_call.cfg
@@ -2,13 +2,13 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 
     ; GDScript: identifiers.gd
@@ -16,8 +16,8 @@ include=[
     {"display": "test_signal_2"},
     {"display": "test_var_1"},
     {"display": "test_var_2"},
-    {"display": "test_func_1"},
-    {"display": "test_func_2"},
+    {"display": "test_func_1(…)"},
+    {"display": "test_func_2(…)"},
     {"display": "test_parameter_1"},
     {"display": "test_parameter_2"},
     {"display": "local_test_var_1"},

--- a/modules/gdscript/tests/scripts/completion/common/identifiers_in_function_body.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/identifiers_in_function_body.cfg
@@ -2,13 +2,13 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 
     ; GDScript: identifiers.gd
@@ -16,8 +16,8 @@ include=[
     {"display": "test_signal_2"},
     {"display": "test_var_1"},
     {"display": "test_var_2"},
-    {"display": "test_func_1"},
-    {"display": "test_func_2"},
+    {"display": "test_func_1(…)"},
+    {"display": "test_func_2(…)"},
     {"display": "test_parameter_1"},
     {"display": "test_parameter_2"},
     {"display": "local_test_var_1"},

--- a/modules/gdscript/tests/scripts/completion/common/identifiers_in_unclosed_call.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/identifiers_in_unclosed_call.cfg
@@ -2,13 +2,13 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 
     ; GDScript: identifiers.gd
@@ -16,8 +16,8 @@ include=[
     {"display": "test_signal_2"},
     {"display": "test_var_1"},
     {"display": "test_var_2"},
-    {"display": "test_func_1"},
-    {"display": "test_func_2"},
+    {"display": "test_func_1(…)"},
+    {"display": "test_func_2(…)"},
     {"display": "test_parameter_1"},
     {"display": "test_parameter_2"},
     {"display": "local_test_var_1"},

--- a/modules/gdscript/tests/scripts/completion/common/no_completion_in_string.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/no_completion_in_string.cfg
@@ -2,14 +2,14 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 exclude=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 
     ; GDScript: no_completion_in_string.gd
@@ -17,8 +17,8 @@ exclude=[
     {"display": "test_signal_2"},
     {"display": "test_var_1"},
     {"display": "test_var_2"},
-    {"display": "test_func_1"},
-    {"display": "test_func_2"},
+    {"display": "test_func_1(…)"},
+    {"display": "test_func_2(…)"},
     {"display": "test_parameter_1"},
     {"display": "test_parameter_2"},
     {"display": "local_test_var_1"},

--- a/modules/gdscript/tests/scripts/completion/common/self.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/self.cfg
@@ -2,13 +2,13 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 
     ; GDScript: self.gd
@@ -16,6 +16,6 @@ include=[
     {"display": "test_signal_2"},
     {"display": "test_var_1"},
     {"display": "test_var_2"},
-    {"display": "test_func_1"},
-    {"display": "test_func_2"},
+    {"display": "test_func_1(…)"},
+    {"display": "test_func_2(…)"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/literal/dollar.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/literal/dollar.cfg
@@ -1,7 +1,7 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/literal/percent.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/literal/percent.cfg
@@ -1,7 +1,7 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/literal_scene/dollar_class_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/literal_scene/dollar_class_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/literal_scene/dollar_native_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/literal_scene/dollar_native_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; AnimationPlayer
     {"display": "autoplay"},
-    {"display": "play"},
+    {"display": "play(…)"},
     {"display": "animation_changed"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/literal_scene/percent_class_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/literal_scene/percent_class_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/literal_scene/percent_native_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/literal_scene/percent_native_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; AnimationPlayer
     {"display": "autoplay"},
-    {"display": "play"},
+    {"display": "play(…)"},
     {"display": "animation_changed"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local/local.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local/local.cfg
@@ -1,7 +1,7 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_infered/local_infered.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_infered/local_infered.cfg
@@ -1,7 +1,7 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_infered_scene/class_local_infered_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_infered_scene/class_local_infered_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_infered_scene/native_local_infered_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_infered_scene/native_local_infered_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; AnimationPlayer
     {"display": "autoplay"},
-    {"display": "play"},
+    {"display": "play(…)"},
     {"display": "animation_changed"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_scene/class_local_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_scene/class_local_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_scene/native_local_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_scene/native_local_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; AnimationPlayer
     {"display": "autoplay"},
-    {"display": "play"},
+    {"display": "play(…)"},
     {"display": "animation_changed"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_typehint/class_local_typehint.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_typehint/class_local_typehint.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_typehint/native_local_typehint.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_typehint/native_local_typehint.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; AnimationPlayer
     {"display": "autoplay"},
-    {"display": "play"},
+    {"display": "play(…)"},
     {"display": "animation_changed"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene/class_local_typehint_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene/class_local_typehint_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene/native_local_typehint_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene/native_local_typehint_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; AnimationPlayer
     {"display": "autoplay"},
-    {"display": "play"},
+    {"display": "play(…)"},
     {"display": "animation_changed"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene_broad/class_local_typehint_scene_broad.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene_broad/class_local_typehint_scene_broad.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene_broad/native_local_typehint_scene_broad.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene_broad/native_local_typehint_scene_broad.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; AnimationPlayer
     {"display": "autoplay"},
-    {"display": "play"},
+    {"display": "play(…)"},
     {"display": "animation_changed"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene_incompatible/class_local_typehint_scene_incompatible.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene_incompatible/class_local_typehint_scene_incompatible.cfg
@@ -3,18 +3,18 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; Area2D
-    {"display": "get_overlapping_areas"},
+    {"display": "get_overlapping_areas()"},
     {"display": "linear_damp"},
     {"display": "area_entered"},
 ]
 exclude=[
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene_incompatible/native_local_typehint_scene_incompatible.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/local_typehint_scene_incompatible/native_local_typehint_scene_incompatible.cfg
@@ -3,18 +3,18 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; Area2D
-    {"display": "get_overlapping_areas"},
+    {"display": "get_overlapping_areas()"},
     {"display": "linear_damp"},
     {"display": "area_entered"},
 ]
 exclude=[
     ; AnimationPlayer
     {"display": "autoplay"},
-    {"display": "play"},
+    {"display": "play(…)"},
     {"display": "animation_changed"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member/member.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member/member.cfg
@@ -1,7 +1,7 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_infered/member_infered.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_infered/member_infered.cfg
@@ -1,7 +1,7 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_infered_scene/class_member_infered_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_infered_scene/class_member_infered_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_infered_scene/native_member_infered_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_infered_scene/native_member_infered_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; AnimationPlayer
     {"display": "autoplay"},
-    {"display": "play"},
+    {"display": "play(…)"},
     {"display": "animation_changed"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_scene/class_member_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_scene/class_member_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_scene/native_member_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_scene/native_member_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; AnimationPlayer
     {"display": "autoplay"},
-    {"display": "play"},
+    {"display": "play(…)"},
     {"display": "animation_changed"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_typehint/class_member_typehint.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_typehint/class_member_typehint.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_typehint/native_member_typehint.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_typehint/native_member_typehint.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; AnimationPlayer
     {"display": "autoplay"},
-    {"display": "play"},
+    {"display": "play(…)"},
     {"display": "animation_changed"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene/class_member_typehint_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene/class_member_typehint_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene/native_member_typehint_scene.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene/native_member_typehint_scene.cfg
@@ -3,12 +3,12 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; AnimationPlayer
     {"display": "autoplay"},
-    {"display": "play"},
+    {"display": "play(…)"},
     {"display": "animation_changed"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene_broad/class_member_typehint_scene_broad.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene_broad/class_member_typehint_scene_broad.cfg
@@ -3,7 +3,7 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
@@ -11,6 +11,6 @@ include=[
 exclude=[
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene_broad/native_member_typehint_scene_broad.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene_broad/native_member_typehint_scene_broad.cfg
@@ -3,7 +3,7 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
@@ -11,6 +11,6 @@ include=[
 exclude=[
     ; AnimationPlayer
     {"display": "autoplay"},
-    {"display": "play"},
+    {"display": "play(…)"},
     {"display": "animation_changed"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene_incompatible/class_member_typehint_scene_incompatible.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene_incompatible/class_member_typehint_scene_incompatible.cfg
@@ -3,18 +3,18 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; Area2D
-    {"display": "get_overlapping_areas"},
+    {"display": "get_overlapping_areas()"},
     {"display": "linear_damp"},
     {"display": "area_entered"},
 ]
 exclude=[
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene_incompatible/native_member_typehint_scene_incompatible.cfg
+++ b/modules/gdscript/tests/scripts/completion/get_node/member_typehint_scene_incompatible/native_member_typehint_scene_incompatible.cfg
@@ -3,18 +3,18 @@ scene="res://completion/get_node/get_node.tscn"
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; Area2D
-    {"display": "get_overlapping_areas"},
+    {"display": "get_overlapping_areas()"},
     {"display": "linear_damp"},
     {"display": "area_entered"},
 ]
 exclude=[
     ; AnimationPlayer
     {"display": "autoplay"},
-    {"display": "play"},
+    {"display": "play(…)"},
     {"display": "animation_changed"},
 ]

--- a/modules/gdscript/tests/scripts/completion/types/local/infered.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/local/infered.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/types/local/no_type.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/local/no_type.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/types/local/typehint.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/local/typehint.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/types/local/typehint_broad.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/local/typehint_broad.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/types/local/typehint_incompatible.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/local/typehint_incompatible.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/types/member/infered.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/member/infered.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/types/member/no_type.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/member/no_type.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/types/member/typehint.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/member/typehint.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/types/member/typehint_broad.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/member/typehint_broad.cfg
@@ -1,13 +1,13 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 ]
 exclude=[
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]

--- a/modules/gdscript/tests/scripts/completion/types/member/typehint_incompatible.cfg
+++ b/modules/gdscript/tests/scripts/completion/types/member/typehint_incompatible.cfg
@@ -1,12 +1,12 @@
 [output]
 include=[
     ; Node
-    {"display": "add_child"},
+    {"display": "add_child(…)"},
     {"display": "owner"},
     {"display": "child_entered_tree"},
 
     ; GDScript: class_a.notest.gd
     {"display": "property_of_a"},
-    {"display": "func_of_a"},
+    {"display": "func_of_a()"},
     {"display": "signal_of_a"},
 ]


### PR DESCRIPTION
跟踪自h//ttp//s://githu//b.com/godot//engine/go//dot/pull/99//102 (Remove"//"s as they are used to prevent the original pr from being referenced here)（访问前请删除防引用用的//）
为GDScript的函数补全提示文本添加括号，如果目标函数含有参数，则会在括号内添加一个只占1字符的三句点省略号。
原pr已合并